### PR TITLE
Build: Enforce PR title

### DIFF
--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -1,0 +1,20 @@
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+name: Danger JS
+jobs:
+  dangerJS:
+    name: Danger JS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - uses: actions/checkout@v3
+      - name: Danger JS
+        uses: danger/danger-js@11.2.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --dangerfile scripts/dangerfile.ts

--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
 name: Danger JS
 jobs:

--- a/scripts/dangerfile.ts
+++ b/scripts/dangerfile.ts
@@ -49,7 +49,24 @@ const checkRequiredLabels = (labels: string[]) => {
   }
 };
 
+const checkPrTitle = (title: string) => {
+  const match = title.match(/^[A-Z].+:\s[A-Z].+$/);
+  if (!match) {
+    fail(
+      `PR title must be in the format of "Area: Summary", With both Area and Summary starting with a capital letter
+Good examples:
+- "Docs: Describe Canvas Doc Block"
+- "Svelte: Support Svelte v4"
+Bad examples:
+- "add new api docs"
+- "fix: Svelte 4 support"
+- "Vue: improve docs"`
+    );
+  }
+};
+
 if (prLogConfig) {
   const { labels } = danger.github.issue;
   checkRequiredLabels(labels.map((l) => l.name));
+  checkPrTitle(danger.github.pr.title);
 }


### PR DESCRIPTION
This PR adds the dangerfile back from the original monorepo, and adds a check that ensures PR titles are in a correct format.