### PR TITLE
Fail release PR on unchecked tasks

### DIFF
--- a/.github/workflows/check-release-tasks.yml
+++ b/.github/workflows/check-release-tasks.yml
@@ -8,7 +8,6 @@ on:
       - edited
     branches:
       - 'release/**'
-      - 'next-v2'
 
 jobs:
   task-check:

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+    branches:
+      - 'release/**'
+      - 'next-v2'
+
+jobs:
+  task-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: chromaui/task-completed-checker-action@main
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -1,3 +1,6 @@
+name: Check release tasks
+run-name: 'Check tasks for "${{ github.event.pull_request.title }}" PR'
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
This PR introduces a workflow that fails as long as the PR description has unchecked checkboxes.

- [ ] this should fail it if it is unchecked.